### PR TITLE
Persist metrics in Prom for x time after peers leave

### DIFF
--- a/peerlastseen/peerLastSeen.go
+++ b/peerlastseen/peerLastSeen.go
@@ -1,0 +1,123 @@
+package peerlastseen
+
+import (
+    "errors"
+    "sync"
+    "time"
+
+    "github.com/libp2p/go-libp2p-core/peer"
+)
+
+type PeerLastSeenCB func(peer.ID)
+
+// TODO: Merge PeerLastSeen code into common/p2putil?
+// Similar to libp2p's 'identify' package's ObservedAddr, but for IDs rather
+// than specific multiaddresses
+type PeerLastSeen struct {
+    mutex           sync.RWMutex
+    lastSeen        map[peer.ID]time.Time
+
+    // Peers last seen longer than the timeout duration will be removed.
+    timeout         time.Duration
+
+    // Indicates if the background peer clean-up goroutine is active.
+    // The info in this data structure should be considered stale
+    // if the goroutine is offline.
+    cleanupActive   bool
+
+    // Optional callback invoked by background clean-up goroutine whenever
+    // a peer's timeout is up. Up to user to ensure its thread-safe.
+    callback        PeerLastSeenCB
+}
+
+func NewPeerLastSeen(dur time.Duration, cb PeerLastSeenCB) (*PeerLastSeen, error) {
+    if (dur <= 0) {
+        return nil, errors.New("Unable to set timeout to a value <= 0")
+    }
+
+    pls := &PeerLastSeen {
+        lastSeen:       make(map[peer.ID]time.Time),
+        timeout:        dur,
+        cleanupActive:  false,
+        callback:       cb,
+    }
+
+    // Start background goroutine and wait for it to come up
+    go pls.autoRemove()
+    for pls.cleanupActive == false {
+        time.Sleep(time.Millisecond)
+    }
+
+    return pls, nil
+}
+
+func (pls *PeerLastSeen) UpdateLastSeen(id peer.ID) {
+    now := time.Now()
+
+    pls.mutex.Lock()
+    defer pls.mutex.Unlock()
+
+    pls.lastSeen[id] = now
+}
+
+// Returns timestamp of when peer with given 'id' was last seen
+// Use absolute time rather than duration in case 'id' is not in
+// the map and we return the default 0-value
+func (pls *PeerLastSeen) LastSeen(id peer.ID) (time.Time, error) {
+    if pls.cleanupActive == false {
+        return time.Time{}, errors.New("Background clean-up goroutine for PeerLastSeen is offline")
+    }
+
+    pls.mutex.RLock()
+    defer pls.mutex.RUnlock()
+
+    timestamp := pls.lastSeen[id]
+    return timestamp, nil
+}
+
+// Creates a background goroutine to automatically clear peers
+// that are older than the 'timeout' value set
+func (pls *PeerLastSeen) autoRemove() {
+    if pls.cleanupActive {
+        return // This should not be called twice...
+    }
+
+    pls.cleanupActive = true
+    defer func() {
+        // If this goroutine ever crashes, all other methods should fail
+        pls.cleanupActive = false
+    }()
+
+    // Currently hard-coded to check every second... is this too much?
+    // TODO: Think about how to make this more scalable using info from
+    //       the lastSeen map... perhaps manually set new ticks each time.
+    ticker := time.NewTicker(time.Second)
+    defer ticker.Stop()
+
+    for {
+        <-ticker.C
+
+        // Put cleanup process in a separate goroutine so the mutex defer
+        // is local within it, otherwise the defer will apply to this
+        // scope, and will never be Unlock()'d so long as its running.
+        //
+        // Could manually call Unlock(), but there's a chance of
+        // a panic/crash, and Unlock() would never be called.
+        go func() {
+            pls.mutex.Lock()
+            defer pls.mutex.Unlock()
+
+            for id, ts := range(pls.lastSeen) {
+                if time.Since(ts) > pls.timeout {
+                    delete(pls.lastSeen, id)
+
+                    if pls.callback != nil {
+                        go pls.callback(id)
+                    }
+                }
+            }
+        }()
+    }
+}
+
+

--- a/peerlastseen/peerLastSeen_test.go
+++ b/peerlastseen/peerLastSeen_test.go
@@ -1,0 +1,143 @@
+package peerlastseen
+
+import (
+    "fmt"
+    "testing"
+    "time"
+
+    "github.com/libp2p/go-libp2p-core/peer"
+)
+
+var (
+    callback = func(id peer.ID) {
+        fmt.Println("\nDummy callback called for id\n", string(id))
+    }
+)
+
+const (
+    fakeID1 = peer.ID("Yo-I-got-a-fake-ID-though")
+    fakeID2 = peer.ID("McLOVIN")
+)
+
+func TestCreatePLS(test *testing.T) {
+    test.Run("CreatePLS-no-CB", func(test *testing.T) {
+        pls, err := NewPeerLastSeen(5 * time.Second, nil)
+        if err != nil || pls == nil {
+            test.Errorf("NewPeerLastSeen() with no callback failed:\n%v", err)
+        }
+    })
+
+    test.Run("CreatePLS-with-CB", func(test *testing.T) {
+        pls, err := NewPeerLastSeen(5 * time.Second, callback)
+        if err != nil || pls == nil {
+            test.Errorf("NewPeerLastSeen() with callback failed:\n%v", err)
+        }
+    })
+
+    test.Run("CreatePLS-NegDur", func(test *testing.T) {
+        pls, err := NewPeerLastSeen(-5 * time.Second, callback)
+        if err == nil || pls != nil {
+            test.Errorf("NewPeerLastSeen() with negative duration succeeded, expected it to fail")
+        }
+    })
+}
+
+func TestUpdateLastSeen(test *testing.T) {
+    pls := &PeerLastSeen {
+        lastSeen:       make(map[peer.ID]time.Time),
+        timeout:        5 * time.Second,
+        cleanupActive:  false,
+        callback:       callback,
+    }
+
+    // Tests case where background clean-up groutine isn't active
+    test.Run("UpdateLastSeen-no-cleanup", func(test *testing.T) {
+        err := pls.UpdateLastSeen(fakeID1)
+        if err == nil {
+            test.Fatalf("UpdateLastSeen() without cleanup goroutine succeeded, expected it to fail")
+        }
+    })
+
+    // Activate background goroutine and re-test
+    go pls.autoRemove()
+    for pls.cleanupActive == false {
+        time.Sleep(time.Millisecond)
+    }
+
+    test.Run("UpdateLastSeen", func(test *testing.T) {
+        err := pls.UpdateLastSeen(fakeID1)
+        if err != nil {
+            test.Fatalf("UpdateLastSeen() failed:\n%v", err)
+        }
+    })
+}
+
+func TestLastSeen(test *testing.T) {
+    pls := &PeerLastSeen {
+        lastSeen:       make(map[peer.ID]time.Time),
+        timeout:        5 * time.Second,
+        cleanupActive:  false,
+        callback:       callback,
+    }
+
+    now := time.Now()
+    pls.lastSeen[fakeID2] = now
+
+    test.Run("LastSeen-no-cleanup", func(test *testing.T) {
+        _, err := pls.LastSeen(fakeID2)
+        if err == nil {
+            test.Fatalf("LastSeen() without cleanup goroutine succeeded, expected it to fail")
+        }
+    })
+
+    // Activate background goroutine and re-test
+    go pls.autoRemove()
+    for pls.cleanupActive == false {
+        time.Sleep(time.Millisecond)
+    }
+
+    test.Run("LastSeen", func(test *testing.T) {
+        ts, err := pls.LastSeen(fakeID2)
+        if err != nil {
+            test.Errorf("LastSeen() returned an error:\n%v", err)
+        }
+
+        if ts != now {
+            test.Errorf("LastSeen() returned timestmap %s, expected %s", ts, now)
+        }
+    })
+}
+
+func TestBackgroundCleanUp(test *testing.T) {
+    pls := &PeerLastSeen {
+        lastSeen:       make(map[peer.ID]time.Time),
+        timeout:        5 * time.Second,
+        cleanupActive:  false,
+        callback:       callback,
+    }
+
+    // Activate background goroutine and re-test
+    go pls.autoRemove()
+    for pls.cleanupActive == false {
+        time.Sleep(time.Millisecond)
+    }
+
+    // Insert 2 IDs, spaced apart by 3 seconds.
+    // Then do a sanity-check to see if the length of lastSeen is 2.
+    // Wait another 3 seconds (past the timeout period) and check the
+    // length of lastSeen is 1.
+    pls.lastSeen[fakeID1] = time.Now()
+    time.Sleep(3 * time.Second)
+    pls.lastSeen[fakeID2] = time.Now()
+
+    if len(pls.lastSeen) != 2 {
+        test.Fatalf("Expected length of 'lastSeen' in PLS to be 2, but was %d", len(pls.lastSeen))
+    }
+
+    time.Sleep(3 * time.Second)
+
+    if len(pls.lastSeen) != 1 {
+        test.Fatalf("Expected length of 'lastSeen' in PLS to be 1, but was %d", len(pls.lastSeen))
+    }
+}
+

--- a/ping-monitor/ping-monitor.go
+++ b/ping-monitor/ping-monitor.go
@@ -62,7 +62,7 @@ func collect(node *p2pnode.Node, pingGaugeVec *prometheus.GaugeVec,
         ctx, cancel := context.WithTimeout(node.Ctx, time.Second)
 
         // Get peer in Peerstore
-        for _, id := range node.Host.Peerstore().Peers() {
+        for _, id := range node.Host.Network().Peers() {
             if id == node.Host.ID() {
                 continue
             }


### PR DESCRIPTION
Won't continue trying to ping peers who have disconnected.
However, it will persist the metrics in Prometheus for some time (e.g. in case of flaky connection from peers, or if the peer is restarting / rebooting).

Resolves #3 and resolves #5 